### PR TITLE
Simplify code checks only using ruff

### DIFF
--- a/dbt-dlt/Makefile
+++ b/dbt-dlt/Makefile
@@ -21,12 +21,15 @@ duckdb: # Run DuckDB console.
 
 .PHONY: lint
 lint: # Run code linter tools.
-	sqlfluff lint --dialect duckdb
-	sqlfluff fix --dialect duckdb
-	black .
-	isort .
-	ruff check
-	mypy .
+	@{ \
+		sqlfluff lint --dialect duckdb; exit_code=$$?; \
+		sqlfluff fix --dialect duckdb; exit_code=$$?; \
+		ruff check --select "E,F,UP,B,SIM,I"; exit_code=$$?; \
+		ruff check --fix --select "E,F,UP,B,SIM,I"; exit_code=$$((exit_code | $$?)); \
+		ruff format; exit_code=$$((exit_code | $$?)); \
+		mypy .; exit_code=$$((exit_code | $$?)); \
+		exit $$exit_code; \
+	}
 
 .PHONY: dbt-deps
 dbt-deps: # Install dbt deps (packages).

--- a/dbt-dlt/ingest_aviation_data.py
+++ b/dbt-dlt/ingest_aviation_data.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 import dlt
 from dlt.sources.rest_api import rest_api_source
 

--- a/dbt-dlt/models/flights/schema.yml
+++ b/dbt-dlt/models/flights/schema.yml
@@ -98,7 +98,6 @@ models:
         data_tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: varchar
-          - dbt_expectations.expect_column_values_to_not_be_null
 
       - name: aircraft_type
         description: "Aircraft type"

--- a/dbt-dlt/requirements.txt
+++ b/dbt-dlt/requirements.txt
@@ -1,7 +1,5 @@
 dbt-duckdb==1.9.1
 dlt==1.6.1
 sqlfluff-templater-dbt==3.3.0
-black==25.1.0
-isort==6.0.0
 ruff==0.9.5
 mypy==1.15.0


### PR DESCRIPTION
Replace `black` and `isort` with `ruff`.